### PR TITLE
ci: Add GitHub Actions workflow for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, joss-paper]
+  pull_request:
+    branches: [main, joss-paper]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package
+        run: pip install .
+
+      - name: Run tests
+        run: |
+          python -c "
+          from imlresearch.api.tests import run_all_tests
+          result = run_all_tests()
+          exit(0 if result.wasSuccessful() else 1)
+          "


### PR DESCRIPTION
Run test suite on push/PR to main and joss-paper branches. Tests Python 3.10 and 3.12 on Ubuntu with pip caching.

Addresses #4 

Running example for CI on Python 3.10 and 3.12: https://github.com/goelakash/ImageMLResearch/pull/1

@SiulRek @schappag 